### PR TITLE
"fixed" the sudoers line in the Dockerfile.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ RUN chown -R vagrant: /home/vagrant/.ssh
 RUN echo -n 'vagrant:vagrant' | chpasswd
 
 # Enable passwordless sudo for the "vagrant" user
-RUN echo 'vagrant ALL=NOPASSWD: ALL' > /etc/sudoers.d/vagrant
+RUN echo 'vagrant ALL=(ALL) NOPASSWD: ALL' > /etc/sudoers.d/vagrant
 
 
 CMD /usr/sbin/sshd -D -o UseDNS=no -o UsePAM=no


### PR DESCRIPTION
i had to made this change to get provisioning working with ansible in the docker container. else it couldnt use "become_user" in the ansible playbook file. i dont know if this has some side-effects but after i changed this it worked out. so i thought i make a pull request and see if you can use it or not :) thanks for your great repo. it was alot help for getting started with vagrant + docker.